### PR TITLE
feat: add manifest for ocis app loading

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,3 @@
+{
+	"entrypoint": "extension.js"
+}


### PR DESCRIPTION
oCIS needs apps to have a `manifest.json` file in order to make use of the new app loading mechanism, see https://owncloud.dev/services/web/#web-apps

Since you already use `vite` it's sufficient to have the manifest in a `public` folder in order to get it copied into the `dist` folder on `pnpm build`. 